### PR TITLE
fix(main): cors client

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: npm start
+webDebug: npm run start-dev

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "ISTANBUL_OPTS": "--report lcov"
   },
   "scripts": {
-    "precompile": "rm -rf dist",
-    "compile": "./node_modules/.bin/babel -d dist/ src/",
-    "start": "npm run compile && DEBUG=mottr node dist/server.js",
     "codeclimate": "./node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info",
+    "compile": "./node_modules/.bin/babel -d dist/ src/",
+    "precompile": "rm -rf dist",
+    "start": "npm run compile && node dist/server.js",
+    "start-dev": "npm run compile && DEBUG=mottr node --debug-brk=5858 dist/server.js",
     "test": "NODE_ENV=test babel-node ./node_modules/istanbul/lib/cli.js cover ./node_modules/.bin/_mocha -- src/test/index.js",
     "posttest": "npm run codeclimate",
     "test-unit": "NODE_ENV=test TEST_DIR=unit mocha --compilers js:babel-core/register src/test/index.js",
@@ -40,7 +41,9 @@
     "app-module-path": "1.0.6",
     "babel-cli": "6.8.0",
     "babel-core": "6.8.0",
+    "babel-polyfill": "6.9.1",
     "babel-preset-es2015": "6.6.0",
+    "babel-preset-stage-0": "6.5.0",
     "body-parser": "^1.15.0",
     "cors": "2.7.1",
     "debug": "2.2.0",
@@ -52,8 +55,6 @@
   },
   "devDependencies": {
     "babel-eslint": "6.0.4",
-    "babel-polyfill": "6.9.0",
-    "babel-preset-stage-0": "6.5.0",
     "chai": "3.5.0",
     "chai-as-promised": "5.3.0",
     "codeclimate-test-reporter": "0.3.1",

--- a/src/config/staging.js
+++ b/src/config/staging.js
@@ -7,5 +7,5 @@ export default {
     },
   },
   port: process.env.PORT,
-  host: 'https://mottr-client-staging.herokuapp.com',
+  host: 'http://mottr-client-staging.herokuapp.com',
 };


### PR DESCRIPTION
This fixes the error on the server by moving the packages `babel-preset-stage-0` and `babel-polyfill`, which were used to implement the `async` in the `server.js` file, from *devDependencies* to *dependencies*. This is not ideal and **will be refactored at a later time**.